### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/do-or-paste/c59b07c0-ba9a-49b9-90f5-0f2a920c70a0/305d6441-f4f0-4423-b736-75d5fd513dd4/_apis/work/boardbadge/fb181b68-a8d2-4f9b-b9e2-7107e2376d9c)](https://dev.azure.com/do-or-paste/c59b07c0-ba9a-49b9-90f5-0f2a920c70a0/_boards/board/t/305d6441-f4f0-4423-b736-75d5fd513dd4/Microsoft.EpicCategory)
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#75](https://dev.azure.com/do-or-paste/c59b07c0-ba9a-49b9-90f5-0f2a920c70a0/_workitems/edit/75). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.